### PR TITLE
remove railway dash lines from minor roads

### DIFF
--- a/style.json
+++ b/style.json
@@ -856,7 +856,7 @@
         "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5"
       },
       "source": "openmaptiles",
-      "source-layer": "transportation_name",
+      "source-layer": "transportation",
       "minzoom": 16,
       "filter": [
         "all",
@@ -868,7 +868,11 @@
         [
           "==",
           "class",
-          "minor"
+          "rail"
+        ],
+        [
+          "has",
+          "service"
         ]
       ],
       "layout": {


### PR DESCRIPTION
This regressed in [e30d097e](https://github.com/openmaptiles/positron-gl-style/commit/e30d097eda0cc9f49e53e3b4fe14d38cc964d0b5#diff-ed432438db2de4dd0ecd05b0f3371dc3R878). Looks like a simple copy-paste(?) mistake to me since it doesn't match the source layer and filters of the *railway-service* layer above which the layer originally referred to.