### PR TITLE
Migrate MapLibre Style Expressions

### DIFF
--- a/style.json
+++ b/style.json
@@ -38,7 +38,7 @@
       "type": "fill",
       "source": "openmaptiles",
       "source-layer": "park",
-      "filter": ["==", "$type", "Polygon"],
+      "filter": ["==", ["geometry-type"], "Polygon"],
       "layout": {"visibility": "visible"},
       "paint": {"fill-color": "rgb(230, 233, 229)"}
     },
@@ -49,8 +49,8 @@
       "source-layer": "water",
       "filter": [
         "all",
-        ["==", "$type", "Polygon"],
-        ["!=", "brunnel", "tunnel"]
+        ["==", ["geometry-type"], "Polygon"],
+        ["!=", ["get", "brunnel"], "tunnel"]
       ],
       "layout": {"visibility": "visible"},
       "paint": {"fill-antialias": true, "fill-color": "rgb(194, 200, 202)"}
@@ -63,11 +63,11 @@
       "maxzoom": 8,
       "filter": [
         "all",
-        ["==", "$type", "Polygon"],
-        ["==", "subclass", "ice_shelf"]
+        ["==", ["geometry-type"], "Polygon"],
+        ["==", ["get", "subclass"], "ice_shelf"]
       ],
       "layout": {"visibility": "visible"},
-      "paint": {"fill-color": "hsl(0, 0%, 98%)", "fill-opacity": 0.7}
+      "paint": {"fill-color": "hsl(0,0%,98%)", "fill-opacity": 0.7}
     },
     {
       "id": "landcover_glacier",
@@ -77,13 +77,13 @@
       "maxzoom": 8,
       "filter": [
         "all",
-        ["==", "$type", "Polygon"],
-        ["==", "subclass", "glacier"]
+        ["==", ["geometry-type"], "Polygon"],
+        ["==", ["get", "subclass"], "glacier"]
       ],
       "layout": {"visibility": "visible"},
       "paint": {
-        "fill-color": "hsl(0, 0%, 98%)",
-        "fill-opacity": {"base": 1, "stops": [[0, 1], [8, 0.5]]}
+        "fill-color": "hsl(0,0%,98%)",
+        "fill-opacity": ["interpolate", ["linear"], ["zoom"], 0, 1, 8, 0.5]
       }
     },
     {
@@ -94,13 +94,21 @@
       "maxzoom": 16,
       "filter": [
         "all",
-        ["==", "$type", "Polygon"],
-        ["==", "class", "residential"]
+        ["==", ["geometry-type"], "Polygon"],
+        ["==", ["get", "class"], "residential"]
       ],
       "layout": {"visibility": "visible"},
       "paint": {
         "fill-color": "rgb(234, 234, 230)",
-        "fill-opacity": {"base": 0.6, "stops": [[8, 0.8], [9, 0.6]]}
+        "fill-opacity": [
+          "interpolate",
+          ["exponential", 0.6],
+          ["zoom"],
+          8,
+          0.8,
+          9,
+          0.6
+        ]
       }
     },
     {
@@ -109,11 +117,15 @@
       "source": "openmaptiles",
       "source-layer": "landcover",
       "minzoom": 10,
-      "filter": ["all", ["==", "$type", "Polygon"], ["==", "class", "wood"]],
+      "filter": [
+        "all",
+        ["==", ["geometry-type"], "Polygon"],
+        ["==", ["get", "class"], "wood"]
+      ],
       "layout": {"visibility": "visible"},
       "paint": {
         "fill-color": "rgb(220,224,220)",
-        "fill-opacity": {"base": 1, "stops": [[8, 0], [12, 1]]}
+        "fill-opacity": ["interpolate", ["linear"], ["zoom"], 8, 0, 12, 1]
       }
     },
     {
@@ -121,20 +133,25 @@
       "type": "line",
       "source": "openmaptiles",
       "source-layer": "waterway",
-      "filter": ["==", "$type", "LineString"],
+      "filter": ["==", ["geometry-type"], "LineString"],
       "layout": {"visibility": "visible"},
-      "paint": {"line-color": "hsl(195, 17%, 78%)"}
+      "paint": {"line-color": "hsl(195,17%,78%)"}
     },
     {
       "id": "water_name",
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "water_name",
-      "filter": ["==", "$type", "LineString"],
+      "filter": ["==", ["geometry-type"], "LineString"],
       "layout": {
         "symbol-placement": "line",
         "symbol-spacing": 500,
-        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-field": [
+          "concat",
+          ["get", "name:latin"],
+          "\n",
+          ["get", "name:nonlatin"]
+        ],
         "text-font": ["Metropolis Medium Italic", "Noto Sans Italic"],
         "text-rotation-alignment": "map",
         "text-size": 12
@@ -167,8 +184,12 @@
       "minzoom": 6,
       "filter": [
         "all",
-        ["==", "$type", "LineString"],
-        ["all", ["==", "brunnel", "tunnel"], ["==", "class", "motorway"]]
+        ["==", ["geometry-type"], "LineString"],
+        [
+          "all",
+          ["==", ["get", "brunnel"], "tunnel"],
+          ["==", ["get", "class"], "motorway"]
+        ]
       ],
       "layout": {
         "line-cap": "butt",
@@ -178,7 +199,17 @@
       "paint": {
         "line-color": "rgb(213, 213, 213)",
         "line-opacity": 1,
-        "line-width": {"base": 1.4, "stops": [[5.8, 0], [6, 3], [20, 40]]}
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.4],
+          ["zoom"],
+          5.8,
+          0,
+          6,
+          3,
+          20,
+          40
+        ]
       }
     },
     {
@@ -190,8 +221,12 @@
       "minzoom": 6,
       "filter": [
         "all",
-        ["==", "$type", "LineString"],
-        ["all", ["==", "brunnel", "tunnel"], ["==", "class", "motorway"]]
+        ["==", ["geometry-type"], "LineString"],
+        [
+          "all",
+          ["==", ["get", "brunnel"], "tunnel"],
+          ["==", ["get", "class"], "motorway"]
+        ]
       ],
       "layout": {
         "line-cap": "round",
@@ -200,7 +235,17 @@
       },
       "paint": {
         "line-color": "rgb(234,234,234)",
-        "line-width": {"base": 1.4, "stops": [[4, 2], [6, 1.3], [20, 30]]}
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.4],
+          ["zoom"],
+          4,
+          2,
+          6,
+          1.3,
+          20,
+          30
+        ]
       }
     },
     {
@@ -210,16 +255,24 @@
       "source": "openmaptiles",
       "source-layer": "aeroway",
       "minzoom": 12,
-      "filter": ["all", ["in", "class", "taxiway"]],
+      "filter": ["match", ["get", "class"], ["taxiway"], true, false],
       "layout": {
         "line-cap": "round",
         "line-join": "round",
         "visibility": "visible"
       },
       "paint": {
-        "line-color": "hsl(0, 0%, 88%)",
+        "line-color": "hsl(0,0%,88%)",
         "line-opacity": 1,
-        "line-width": {"base": 1.55, "stops": [[13, 1.8], [20, 20]]}
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.55],
+          ["zoom"],
+          13,
+          1.8,
+          20,
+          20
+        ]
       }
     },
     {
@@ -229,16 +282,24 @@
       "source": "openmaptiles",
       "source-layer": "aeroway",
       "minzoom": 11,
-      "filter": ["all", ["in", "class", "runway"]],
+      "filter": ["match", ["get", "class"], ["runway"], true, false],
       "layout": {
         "line-cap": "round",
         "line-join": "round",
         "visibility": "visible"
       },
       "paint": {
-        "line-color": "hsl(0, 0%, 88%)",
+        "line-color": "hsl(0,0%,88%)",
         "line-opacity": 1,
-        "line-width": {"base": 1.5, "stops": [[11, 6], [17, 55]]}
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          11,
+          6,
+          17,
+          55
+        ]
       }
     },
     {
@@ -250,13 +311,13 @@
       "minzoom": 4,
       "filter": [
         "all",
-        ["==", "$type", "Polygon"],
-        ["in", "class", "runway", "taxiway"]
+        ["==", ["geometry-type"], "Polygon"],
+        ["match", ["get", "class"], ["runway", "taxiway"], true, false]
       ],
       "layout": {"visibility": "visible"},
       "paint": {
         "fill-color": "rgba(255, 255, 255, 1)",
-        "fill-opacity": {"base": 1, "stops": [[13, 0], [14, 1]]}
+        "fill-opacity": ["interpolate", ["linear"], ["zoom"], 13, 0, 14, 1]
       }
     },
     {
@@ -268,8 +329,8 @@
       "minzoom": 11,
       "filter": [
         "all",
-        ["in", "class", "runway"],
-        ["==", "$type", "LineString"]
+        ["match", ["get", "class"], ["runway"], true, false],
+        ["==", ["geometry-type"], "LineString"]
       ],
       "layout": {
         "line-cap": "round",
@@ -279,7 +340,15 @@
       "paint": {
         "line-color": "rgba(255, 255, 255, 1)",
         "line-opacity": 1,
-        "line-width": {"base": 1.5, "stops": [[11, 4], [17, 50]]}
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          11,
+          4,
+          17,
+          50
+        ]
       }
     },
     {
@@ -288,7 +357,11 @@
       "metadata": {},
       "source": "openmaptiles",
       "source-layer": "transportation",
-      "filter": ["all", ["==", "$type", "Polygon"], ["==", "class", "pier"]],
+      "filter": [
+        "all",
+        ["==", ["geometry-type"], "Polygon"],
+        ["==", ["get", "class"], "pier"]
+      ],
       "layout": {"visibility": "visible"},
       "paint": {"fill-antialias": true, "fill-color": "rgb(242,243,240)"}
     },
@@ -298,11 +371,23 @@
       "metadata": {},
       "source": "openmaptiles",
       "source-layer": "transportation",
-      "filter": ["all", ["==", "$type", "LineString"], ["in", "class", "pier"]],
+      "filter": [
+        "all",
+        ["==", ["geometry-type"], "LineString"],
+        ["match", ["get", "class"], ["pier"], true, false]
+      ],
       "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
         "line-color": "rgb(242,243,240)",
-        "line-width": {"base": 1.2, "stops": [[15, 1], [17, 4]]}
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.2],
+          ["zoom"],
+          15,
+          1,
+          17,
+          4
+        ]
       }
     },
     {
@@ -311,7 +396,11 @@
       "metadata": {"mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5"},
       "source": "openmaptiles",
       "source-layer": "transportation",
-      "filter": ["all", ["==", "$type", "LineString"], ["==", "class", "path"]],
+      "filter": [
+        "all",
+        ["==", ["geometry-type"], "LineString"],
+        ["==", ["get", "class"], "path"]
+      ],
       "layout": {
         "line-cap": "round",
         "line-join": "round",
@@ -320,7 +409,15 @@
       "paint": {
         "line-color": "rgb(234, 234, 234)",
         "line-opacity": 0.9,
-        "line-width": {"base": 1.2, "stops": [[13, 1], [20, 10]]}
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.2],
+          ["zoom"],
+          13,
+          1,
+          20,
+          10
+        ]
       }
     },
     {
@@ -332,8 +429,8 @@
       "minzoom": 8,
       "filter": [
         "all",
-        ["==", "$type", "LineString"],
-        ["in", "class", "minor", "service", "track"]
+        ["==", ["geometry-type"], "LineString"],
+        ["match", ["get", "class"], ["minor", "service", "track"], true, false]
       ],
       "layout": {
         "line-cap": "round",
@@ -341,9 +438,17 @@
         "visibility": "visible"
       },
       "paint": {
-        "line-color": "hsl(0, 0%, 88%)",
+        "line-color": "hsl(0,0%,88%)",
         "line-opacity": 0.9,
-        "line-width": {"base": 1.55, "stops": [[13, 1.8], [20, 20]]}
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.55],
+          ["zoom"],
+          13,
+          1.8,
+          20,
+          20
+        ]
       }
     },
     {
@@ -355,8 +460,14 @@
       "minzoom": 11,
       "filter": [
         "all",
-        ["==", "$type", "LineString"],
-        ["in", "class", "primary", "secondary", "tertiary", "trunk"]
+        ["==", ["geometry-type"], "LineString"],
+        [
+          "match",
+          ["get", "class"],
+          ["primary", "secondary", "tertiary", "trunk"],
+          true,
+          false
+        ]
       ],
       "layout": {
         "line-cap": "butt",
@@ -366,7 +477,15 @@
       "paint": {
         "line-color": "rgb(213, 213, 213)",
         "line-dasharray": [12, 0],
-        "line-width": {"base": 1.3, "stops": [[10, 3], [20, 23]]}
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.3],
+          ["zoom"],
+          10,
+          3,
+          20,
+          23
+        ]
       }
     },
     {
@@ -378,8 +497,14 @@
       "minzoom": 11,
       "filter": [
         "all",
-        ["==", "$type", "LineString"],
-        ["in", "class", "primary", "secondary", "tertiary", "trunk"]
+        ["==", ["geometry-type"], "LineString"],
+        [
+          "match",
+          ["get", "class"],
+          ["primary", "secondary", "tertiary", "trunk"],
+          true,
+          false
+        ]
       ],
       "layout": {
         "line-cap": "round",
@@ -388,7 +513,15 @@
       },
       "paint": {
         "line-color": "#fff",
-        "line-width": {"base": 1.3, "stops": [[10, 2], [20, 20]]}
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.3],
+          ["zoom"],
+          10,
+          2,
+          20,
+          20
+        ]
       }
     },
     {
@@ -400,15 +533,21 @@
       "maxzoom": 11,
       "filter": [
         "all",
-        ["==", "$type", "LineString"],
-        ["in", "class", "primary", "secondary", "tertiary", "trunk"]
+        ["==", ["geometry-type"], "LineString"],
+        [
+          "match",
+          ["get", "class"],
+          ["primary", "secondary", "tertiary", "trunk"],
+          true,
+          false
+        ]
       ],
       "layout": {
         "line-cap": "round",
         "line-join": "round",
         "visibility": "visible"
       },
-      "paint": {"line-color": "hsla(0, 0%, 85%, 0.69)", "line-width": 2}
+      "paint": {"line-color": "hsla(0,0%,85%,0.69)", "line-width": 2}
     },
     {
       "id": "highway_motorway_casing",
@@ -419,11 +558,11 @@
       "minzoom": 6,
       "filter": [
         "all",
-        ["==", "$type", "LineString"],
+        ["==", ["geometry-type"], "LineString"],
         [
           "all",
-          ["!in", "brunnel", "bridge", "tunnel"],
-          ["==", "class", "motorway"]
+          ["match", ["get", "brunnel"], ["bridge", "tunnel"], false, true],
+          ["==", ["get", "class"], "motorway"]
         ]
       ],
       "layout": {
@@ -435,7 +574,17 @@
         "line-color": "rgb(213, 213, 213)",
         "line-dasharray": [2, 0],
         "line-opacity": 1,
-        "line-width": {"base": 1.4, "stops": [[5.8, 0], [6, 3], [20, 40]]}
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.4],
+          ["zoom"],
+          5.8,
+          0,
+          6,
+          3,
+          20,
+          40
+        ]
       }
     },
     {
@@ -447,11 +596,11 @@
       "minzoom": 6,
       "filter": [
         "all",
-        ["==", "$type", "LineString"],
+        ["==", ["geometry-type"], "LineString"],
         [
           "all",
-          ["!in", "brunnel", "bridge", "tunnel"],
-          ["==", "class", "motorway"]
+          ["match", ["get", "brunnel"], ["bridge", "tunnel"], false, true],
+          ["==", ["get", "class"], "motorway"]
         ]
       ],
       "layout": {
@@ -460,11 +609,26 @@
         "visibility": "visible"
       },
       "paint": {
-        "line-color": {
-          "base": 1,
-          "stops": [[5.8, "hsla(0, 0%, 85%, 0.53)"], [6, "#fff"]]
-        },
-        "line-width": {"base": 1.4, "stops": [[4, 2], [6, 1.3], [20, 30]]}
+        "line-color": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          5.8,
+          "hsla(0,0%,85%,0.53)",
+          6,
+          "#fff"
+        ],
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.4],
+          ["zoom"],
+          4,
+          2,
+          6,
+          1.3,
+          20,
+          30
+        ]
       }
     },
     {
@@ -476,8 +640,8 @@
       "maxzoom": 6,
       "filter": [
         "all",
-        ["==", "$type", "LineString"],
-        ["==", "class", "motorway"]
+        ["==", ["geometry-type"], "LineString"],
+        ["==", ["get", "class"], "motorway"]
       ],
       "layout": {
         "line-cap": "round",
@@ -485,8 +649,16 @@
         "visibility": "visible"
       },
       "paint": {
-        "line-color": "hsla(0, 0%, 85%, 0.53)",
-        "line-width": {"base": 1.4, "stops": [[4, 2], [6, 1.3]]}
+        "line-color": "hsla(0,0%,85%,0.53)",
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.4],
+          ["zoom"],
+          4,
+          2,
+          6,
+          1.3
+        ]
       }
     },
     {
@@ -498,8 +670,12 @@
       "minzoom": 16,
       "filter": [
         "all",
-        ["==", "$type", "LineString"],
-        ["all", ["==", "class", "transit"], ["!in", "brunnel", "tunnel"]]
+        ["==", ["geometry-type"], "LineString"],
+        [
+          "all",
+          ["==", ["get", "class"], "transit"],
+          ["match", ["get", "brunnel"], ["tunnel"], false, true]
+        ]
       ],
       "layout": {"line-join": "round", "visibility": "visible"},
       "paint": {"line-color": "#dddddd", "line-width": 3}
@@ -513,8 +689,12 @@
       "minzoom": 16,
       "filter": [
         "all",
-        ["==", "$type", "LineString"],
-        ["all", ["==", "class", "transit"], ["!in", "brunnel", "tunnel"]]
+        ["==", ["geometry-type"], "LineString"],
+        [
+          "all",
+          ["==", ["get", "class"], "transit"],
+          ["match", ["get", "brunnel"], ["tunnel"], false, true]
+        ]
       ],
       "layout": {"line-join": "round", "visibility": "visible"},
       "paint": {
@@ -532,8 +712,8 @@
       "minzoom": 16,
       "filter": [
         "all",
-        ["==", "$type", "LineString"],
-        ["all", ["==", "class", "rail"], ["has", "service"]]
+        ["==", ["geometry-type"], "LineString"],
+        ["all", ["==", ["get", "class"], "rail"], ["has", "service"]]
       ],
       "layout": {"line-join": "round", "visibility": "visible"},
       "paint": {"line-color": "#dddddd", "line-width": 3}
@@ -547,8 +727,8 @@
       "minzoom": 16,
       "filter": [
         "all",
-        ["==", "$type", "LineString"],
-        ["==", "class", "rail"],
+        ["==", ["geometry-type"], "LineString"],
+        ["==", ["get", "class"], "rail"],
         ["has", "service"]
       ],
       "layout": {"line-join": "round", "visibility": "visible"},
@@ -567,13 +747,21 @@
       "minzoom": 13,
       "filter": [
         "all",
-        ["==", "$type", "LineString"],
-        ["all", ["!has", "service"], ["==", "class", "rail"]]
+        ["==", ["geometry-type"], "LineString"],
+        ["all", ["!", ["has", "service"]], ["==", ["get", "class"], "rail"]]
       ],
       "layout": {"line-join": "round", "visibility": "visible"},
       "paint": {
         "line-color": "#dddddd",
-        "line-width": {"base": 1.3, "stops": [[16, 3], [20, 7]]}
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.3],
+          ["zoom"],
+          16,
+          3,
+          20,
+          7
+        ]
       }
     },
     {
@@ -585,14 +773,22 @@
       "minzoom": 13,
       "filter": [
         "all",
-        ["==", "$type", "LineString"],
-        ["all", ["!has", "service"], ["==", "class", "rail"]]
+        ["==", ["geometry-type"], "LineString"],
+        ["all", ["!", ["has", "service"]], ["==", ["get", "class"], "rail"]]
       ],
       "layout": {"line-join": "round", "visibility": "visible"},
       "paint": {
         "line-color": "#fafafa",
         "line-dasharray": [3, 3],
-        "line-width": {"base": 1.3, "stops": [[16, 2], [20, 6]]}
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.3],
+          ["zoom"],
+          16,
+          2,
+          20,
+          6
+        ]
       }
     },
     {
@@ -604,8 +800,12 @@
       "minzoom": 6,
       "filter": [
         "all",
-        ["==", "$type", "LineString"],
-        ["all", ["==", "brunnel", "bridge"], ["==", "class", "motorway"]]
+        ["==", ["geometry-type"], "LineString"],
+        [
+          "all",
+          ["==", ["get", "brunnel"], "bridge"],
+          ["==", ["get", "class"], "motorway"]
+        ]
       ],
       "layout": {
         "line-cap": "butt",
@@ -616,7 +816,17 @@
         "line-color": "rgb(213, 213, 213)",
         "line-dasharray": [2, 0],
         "line-opacity": 1,
-        "line-width": {"base": 1.4, "stops": [[5.8, 0], [6, 5], [20, 45]]}
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.4],
+          ["zoom"],
+          5.8,
+          0,
+          6,
+          5,
+          20,
+          45
+        ]
       }
     },
     {
@@ -628,8 +838,12 @@
       "minzoom": 6,
       "filter": [
         "all",
-        ["==", "$type", "LineString"],
-        ["all", ["==", "brunnel", "bridge"], ["==", "class", "motorway"]]
+        ["==", ["geometry-type"], "LineString"],
+        [
+          "all",
+          ["==", ["get", "brunnel"], "bridge"],
+          ["==", ["get", "class"], "motorway"]
+        ]
       ],
       "layout": {
         "line-cap": "round",
@@ -637,11 +851,26 @@
         "visibility": "visible"
       },
       "paint": {
-        "line-color": {
-          "base": 1,
-          "stops": [[5.8, "hsla(0, 0%, 85%, 0.53)"], [6, "#fff"]]
-        },
-        "line-width": {"base": 1.4, "stops": [[4, 2], [6, 1.3], [20, 30]]}
+        "line-color": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          5.8,
+          "hsla(0,0%,85%,0.53)",
+          6,
+          "#fff"
+        ],
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.4],
+          ["zoom"],
+          4,
+          2,
+          6,
+          1.3,
+          20,
+          30
+        ]
       }
     },
     {
@@ -652,13 +881,18 @@
       "source-layer": "transportation_name",
       "filter": [
         "all",
-        ["!=", "class", "motorway"],
-        ["==", "$type", "LineString"]
+        ["!=", ["get", "class"], "motorway"],
+        ["==", ["geometry-type"], "LineString"]
       ],
       "layout": {
         "symbol-placement": "line",
         "symbol-spacing": 350,
-        "text-field": "{name:latin} {name:nonlatin}",
+        "text-field": [
+          "concat",
+          ["get", "name:latin"],
+          " ",
+          ["get", "name:nonlatin"]
+        ],
         "text-font": ["Metropolis Regular", "Noto Sans Regular"],
         "text-max-angle": 30,
         "text-pitch-alignment": "viewport",
@@ -683,13 +917,13 @@
       "source-layer": "transportation_name",
       "filter": [
         "all",
-        ["==", "$type", "LineString"],
-        ["==", "class", "motorway"]
+        ["==", ["geometry-type"], "LineString"],
+        ["==", ["get", "class"], "motorway"]
       ],
       "layout": {
         "symbol-placement": "line",
         "symbol-spacing": 350,
-        "text-field": "{ref}",
+        "text-field": ["to-string", ["get", "ref"]],
         "text-font": ["Metropolis Light", "Noto Sans Regular"],
         "text-pitch-alignment": "viewport",
         "text-rotation-alignment": "viewport",
@@ -699,7 +933,7 @@
       "paint": {
         "text-color": "rgb(117, 129, 145)",
         "text-halo-blur": 1,
-        "text-halo-color": "hsl(0, 0%, 100%)",
+        "text-halo-color": "hsl(0,0%,100%)",
         "text-halo-width": 1,
         "text-translate": [0, 2]
       }
@@ -710,7 +944,7 @@
       "metadata": {"mapbox:group": "a14c9607bc7954ba1df7205bf660433f"},
       "source": "openmaptiles",
       "source-layer": "boundary",
-      "filter": ["==", "admin_level", 4],
+      "filter": ["==", ["get", "admin_level"], 4],
       "layout": {
         "line-cap": "round",
         "line-join": "round",
@@ -721,7 +955,15 @@
         "line-color": "rgb(230, 204, 207)",
         "line-dasharray": [2, 2],
         "line-opacity": 1,
-        "line-width": {"base": 1.3, "stops": [[3, 1], [22, 15]]}
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.3],
+          ["zoom"],
+          3,
+          1,
+          22,
+          15
+        ]
       }
     },
     {
@@ -731,13 +973,25 @@
       "source": "openmaptiles",
       "source-layer": "boundary",
       "maxzoom": 5,
-      "filter": ["all", ["==", "admin_level", 2], ["!has", "claimed_by"]],
+      "filter": [
+        "all",
+        ["==", ["get", "admin_level"], 2],
+        ["!", ["has", "claimed_by"]]
+      ],
       "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
-        "line-blur": {"base": 1, "stops": [[0, 0.4], [22, 4]]},
+        "line-blur": ["interpolate", ["linear"], ["zoom"], 0, 0.4, 22, 4],
         "line-color": "rgb(230, 204, 207)",
         "line-opacity": 1,
-        "line-width": {"base": 1.1, "stops": [[3, 1], [22, 20]]}
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.1],
+          ["zoom"],
+          3,
+          1,
+          22,
+          20
+        ]
       }
     },
     {
@@ -747,13 +1001,21 @@
       "source": "openmaptiles",
       "source-layer": "boundary",
       "minzoom": 5,
-      "filter": ["==", "admin_level", 2],
+      "filter": ["==", ["get", "admin_level"], 2],
       "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
-        "line-blur": {"base": 1, "stops": [[0, 0.4], [22, 4]]},
+        "line-blur": ["interpolate", ["linear"], ["zoom"], 0, 0.4, 22, 4],
         "line-color": "rgb(230, 204, 207)",
         "line-opacity": 1,
-        "line-width": {"base": 1.1, "stops": [[3, 1], [22, 20]]}
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.1],
+          ["zoom"],
+          3,
+          1,
+          22,
+          20
+        ]
       }
     },
     {
@@ -766,18 +1028,22 @@
       "filter": [
         "all",
         [
-          "in",
-          "class",
-          "continent",
-          "hamlet",
-          "neighbourhood",
-          "isolated_dwelling"
+          "match",
+          ["get", "class"],
+          ["continent", "hamlet", "isolated_dwelling", "neighbourhood"],
+          true,
+          false
         ],
-        ["==", "$type", "Point"]
+        ["==", ["geometry-type"], "Point"]
       ],
       "layout": {
         "text-anchor": "center",
-        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-field": [
+          "concat",
+          ["get", "name:latin"],
+          "\n",
+          ["get", "name:nonlatin"]
+        ],
         "text-font": ["Metropolis Regular", "Noto Sans Regular"],
         "text-justify": "center",
         "text-offset": [0.5, 0],
@@ -799,10 +1065,19 @@
       "source": "openmaptiles",
       "source-layer": "place",
       "maxzoom": 15,
-      "filter": ["all", ["==", "$type", "Point"], ["==", "class", "suburb"]],
+      "filter": [
+        "all",
+        ["==", ["geometry-type"], "Point"],
+        ["==", ["get", "class"], "suburb"]
+      ],
       "layout": {
         "text-anchor": "center",
-        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-field": [
+          "concat",
+          ["get", "name:latin"],
+          "\n",
+          ["get", "name:nonlatin"]
+        ],
         "text-font": ["Metropolis Regular", "Noto Sans Regular"],
         "text-justify": "center",
         "text-offset": [0.5, 0],
@@ -824,11 +1099,20 @@
       "source": "openmaptiles",
       "source-layer": "place",
       "maxzoom": 14,
-      "filter": ["all", ["==", "$type", "Point"], ["==", "class", "village"]],
+      "filter": [
+        "all",
+        ["==", ["geometry-type"], "Point"],
+        ["==", ["get", "class"], "village"]
+      ],
       "layout": {
         "icon-size": 0.4,
         "text-anchor": "left",
-        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-field": [
+          "concat",
+          ["get", "name:latin"],
+          "\n",
+          ["get", "name:nonlatin"]
+        ],
         "text-font": ["Metropolis Regular", "Noto Sans Regular"],
         "text-justify": "left",
         "text-offset": [0.5, 0.2],
@@ -851,12 +1135,21 @@
       "source": "openmaptiles",
       "source-layer": "place",
       "maxzoom": 15,
-      "filter": ["all", ["==", "$type", "Point"], ["==", "class", "town"]],
+      "filter": [
+        "all",
+        ["==", ["geometry-type"], "Point"],
+        ["==", ["get", "class"], "town"]
+      ],
       "layout": {
-        "icon-image": {"base": 1, "stops": [[0, "circle-11"], [8, ""]]},
+        "icon-image": ["step", ["zoom"], "circle-11", 8, ""],
         "icon-size": 0.4,
-        "text-anchor": {"base": 1, "stops": [[0, "left"], [8, "center"]]},
-        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-anchor": ["step", ["zoom"], "left", 8, "center"],
+        "text-field": [
+          "concat",
+          ["get", "name:latin"],
+          "\n",
+          ["get", "name:nonlatin"]
+        ],
         "text-font": ["Metropolis Regular", "Noto Sans Regular"],
         "text-justify": "left",
         "text-offset": [0.5, 0.2],
@@ -881,14 +1174,24 @@
       "maxzoom": 14,
       "filter": [
         "all",
-        ["==", "$type", "Point"],
-        ["all", ["!=", "capital", 2], ["==", "class", "city"], [">", "rank", 3]]
+        ["==", ["geometry-type"], "Point"],
+        [
+          "all",
+          ["!=", ["get", "capital"], 2],
+          ["==", ["get", "class"], "city"],
+          [">", ["get", "rank"], 3]
+        ]
       ],
       "layout": {
-        "icon-image": {"base": 1, "stops": [[0, "circle-11"], [8, ""]]},
+        "icon-image": ["step", ["zoom"], "circle-11", 8, ""],
         "icon-size": 0.4,
-        "text-anchor": {"base": 1, "stops": [[0, "left"], [8, "center"]]},
-        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-anchor": ["step", ["zoom"], "left", 8, "center"],
+        "text-field": [
+          "concat",
+          ["get", "name:latin"],
+          "\n",
+          ["get", "name:nonlatin"]
+        ],
         "text-font": ["Metropolis Regular", "Noto Sans Regular"],
         "text-justify": "left",
         "text-offset": [0.5, 0.2],
@@ -913,14 +1216,19 @@
       "maxzoom": 12,
       "filter": [
         "all",
-        ["==", "$type", "Point"],
-        ["all", ["==", "capital", 2], ["==", "class", "city"]]
+        ["==", ["geometry-type"], "Point"],
+        ["all", ["==", ["get", "capital"], 2], ["==", ["get", "class"], "city"]]
       ],
       "layout": {
-        "icon-image": {"base": 1, "stops": [[0, "star-11"], [8, ""]]},
+        "icon-image": ["step", ["zoom"], "star-11", 8, ""],
         "icon-size": 1,
-        "text-anchor": {"base": 1, "stops": [[0, "left"], [8, "center"]]},
-        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-anchor": ["step", ["zoom"], "left", 8, "center"],
+        "text-field": [
+          "concat",
+          ["get", "name:latin"],
+          "\n",
+          ["get", "name:nonlatin"]
+        ],
         "text-font": ["Metropolis Regular", "Noto Sans Regular"],
         "text-justify": "left",
         "text-offset": [0.5, 0.2],
@@ -945,19 +1253,24 @@
       "maxzoom": 12,
       "filter": [
         "all",
-        ["==", "$type", "Point"],
+        ["==", ["geometry-type"], "Point"],
         [
           "all",
-          ["!=", "capital", 2],
-          ["<=", "rank", 3],
-          ["==", "class", "city"]
+          ["!=", ["get", "capital"], 2],
+          ["<=", ["get", "rank"], 3],
+          ["==", ["get", "class"], "city"]
         ]
       ],
       "layout": {
-        "icon-image": {"base": 1, "stops": [[0, "circle-11"], [8, ""]]},
+        "icon-image": ["step", ["zoom"], "circle-11", 8, ""],
         "icon-size": 0.4,
-        "text-anchor": {"base": 1, "stops": [[0, "left"], [8, "center"]]},
-        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-anchor": ["step", ["zoom"], "left", 8, "center"],
+        "text-field": [
+          "concat",
+          ["get", "name:latin"],
+          "\n",
+          ["get", "name:nonlatin"]
+        ],
         "text-font": ["Metropolis Regular", "Noto Sans Regular"],
         "text-justify": "left",
         "text-offset": [0.5, 0.2],
@@ -980,9 +1293,18 @@
       "source": "openmaptiles",
       "source-layer": "place",
       "maxzoom": 12,
-      "filter": ["all", ["==", "$type", "Point"], ["==", "class", "state"]],
+      "filter": [
+        "all",
+        ["==", ["geometry-type"], "Point"],
+        ["==", ["get", "class"], "state"]
+      ],
       "layout": {
-        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-field": [
+          "concat",
+          ["get", "name:latin"],
+          "\n",
+          ["get", "name:nonlatin"]
+        ],
         "text-font": ["Metropolis Regular", "Noto Sans Regular"],
         "text-size": 10,
         "text-transform": "uppercase",
@@ -1004,22 +1326,27 @@
       "maxzoom": 8,
       "filter": [
         "all",
-        ["==", "$type", "Point"],
-        ["==", "class", "country"],
-        ["!has", "iso_a2"]
+        ["==", ["geometry-type"], "Point"],
+        ["==", ["get", "class"], "country"],
+        ["!", ["has", "iso_a2"]]
       ],
       "layout": {
-        "text-field": "{name:latin}",
+        "text-field": ["to-string", ["get", "name:latin"]],
         "text-font": ["Metropolis Light Italic", "Noto Sans Italic"],
-        "text-size": {"base": 1, "stops": [[0, 9], [6, 11]]},
+        "text-size": ["interpolate", ["linear"], ["zoom"], 0, 9, 6, 11],
         "text-transform": "uppercase",
         "visibility": "visible"
       },
       "paint": {
-        "text-color": {
-          "base": 1,
-          "stops": [[3, "rgb(157,169,177)"], [4, "rgb(153, 153, 153)"]]
-        },
+        "text-color": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          3,
+          "rgb(157,169,177)",
+          4,
+          "rgb(153, 153, 153)"
+        ],
         "text-halo-color": "rgba(236,236,234,0.7)",
         "text-halo-width": 1.4
       }
@@ -1033,23 +1360,28 @@
       "maxzoom": 8,
       "filter": [
         "all",
-        ["==", "$type", "Point"],
-        ["==", "class", "country"],
-        [">=", "rank", 2],
+        ["==", ["geometry-type"], "Point"],
+        ["==", ["get", "class"], "country"],
+        [">=", ["get", "rank"], 2],
         ["has", "iso_a2"]
       ],
       "layout": {
-        "text-field": "{name:latin}",
+        "text-field": ["to-string", ["get", "name:latin"]],
         "text-font": ["Metropolis Regular", "Noto Sans Regular"],
-        "text-size": {"base": 1, "stops": [[0, 10], [6, 12]]},
+        "text-size": ["interpolate", ["linear"], ["zoom"], 0, 10, 6, 12],
         "text-transform": "uppercase",
         "visibility": "visible"
       },
       "paint": {
-        "text-color": {
-          "base": 1,
-          "stops": [[3, "rgb(157,169,177)"], [4, "rgb(153, 153, 153)"]]
-        },
+        "text-color": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          3,
+          "rgb(157,169,177)",
+          4,
+          "rgb(153, 153, 153)"
+        ],
         "text-halo-color": "rgba(236,236,234,0.7)",
         "text-halo-width": 1.4
       }
@@ -1063,24 +1395,39 @@
       "maxzoom": 6,
       "filter": [
         "all",
-        ["==", "$type", "Point"],
-        ["<=", "rank", 1],
-        ["==", "class", "country"],
+        ["==", ["geometry-type"], "Point"],
+        ["<=", ["get", "rank"], 1],
+        ["==", ["get", "class"], "country"],
         ["has", "iso_a2"]
       ],
       "layout": {
         "text-anchor": "center",
-        "text-field": "{name:latin}",
+        "text-field": ["to-string", ["get", "name:latin"]],
         "text-font": ["Metropolis Regular", "Noto Sans Regular"],
-        "text-size": {"base": 1.4, "stops": [[0, 10], [3, 12], [4, 14]]},
+        "text-size": [
+          "interpolate",
+          ["exponential", 1.4],
+          ["zoom"],
+          0,
+          10,
+          3,
+          12,
+          4,
+          14
+        ],
         "text-transform": "uppercase",
         "visibility": "visible"
       },
       "paint": {
-        "text-color": {
-          "base": 1,
-          "stops": [[3, "rgb(157,169,177)"], [4, "rgb(153, 153, 153)"]]
-        },
+        "text-color": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          3,
+          "rgb(157,169,177)",
+          4,
+          "rgb(153, 153, 153)"
+        ],
         "text-halo-color": "rgba(236,236,234,0.7)",
         "text-halo-width": 1.4
       }


### PR DESCRIPTION
This PR updates the Positron style to remove legacy MapLibre/Mapbox style syntax that is no longer accepted by recent MapLibre GL JS versions.

I migrated the remaining `base` / `stops` functions, tokenized `text-field` values, and legacy filters to modern style-spec expressions.

## Changes

- Replaced `base` / `stops` functions with `interpolate` or `step`.
- Migrated filters to `geometry-type`, `get`, and `match`.
- Replaced tokenized `text-field` strings with `concat`, `to-string`, and `get`.
- Kept the existing zoom stops, sizes, colors, and opacity values.
